### PR TITLE
Include byte offset in decode errors

### DIFF
--- a/src/decode/helpers.rs
+++ b/src/decode/helpers.rs
@@ -1,7 +1,7 @@
-use crate::Expr;
 use crate::core::instruction::Instruction;
 use crate::decode::instructions;
-use crate::decode::integer::{DecodeU32Error, decode_u32};
+use crate::decode::integer::{decode_u32, DecodeU32Error};
+use crate::Expr;
 use std::io::{self, Read};
 use thiserror::Error;
 

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -13,8 +13,8 @@ pub use helpers::{
     DecodeNameError, ParseExpressionError,
 };
 pub use module::{
-    DecodeModuleError, DecodeSectionHeaderError, InvalidSectionIdError, ParsePreambleError,
-    decode_module,
+    DecodeModuleError, DecodeModuleErrorKind, DecodeSectionHeaderError, InvalidSectionIdError,
+    ParsePreambleError, decode_module,
 };
 
 pub(crate) trait FromMarkerByte

--- a/src/decode/module.rs
+++ b/src/decode/module.rs
@@ -22,11 +22,32 @@ static EXPECTED_PREAMBLE: [u8; 8] = [
     VERSION[3],
 ];
 
+// OffsetReader is a wrapper around a [Read] that tracks the position (offset) of the reader in the
+// input stream.
+struct OffsetReader<R: Read> {
+    reader: R,
+    offset: u64,
+}
+
+impl<R: Read> OffsetReader<R> {
+    fn new(reader: R) -> Self {
+        Self { reader, offset: 0 }
+    }
+}
+
+impl<R: Read> Read for OffsetReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let bytes_read = self.reader.read(buf)?;
+        self.offset += u64::try_from(bytes_read).unwrap();
+        Ok(bytes_read)
+    }
+}
+
 impl Module {
     fn validate_section_kind_expected(
         &self,
         current: &SectionHeader,
-    ) -> Result<(), DecodeModuleError> {
+    ) -> Result<(), DecodeModuleErrorKind> {
         let previous = self.parsed_section_kinds.last();
         let current = current.kind;
 
@@ -39,11 +60,11 @@ impl Module {
         let previous = *previous.unwrap();
 
         if current < previous {
-            return Err(DecodeModuleError::SectionOutOfOrder { current, previous });
+            return Err(DecodeModuleErrorKind::SectionOutOfOrder { current, previous });
         }
 
         if current == previous {
-            return Err(DecodeModuleError::DuplicateSection(current));
+            return Err(DecodeModuleErrorKind::DuplicateSection(current));
         }
 
         Ok(())
@@ -119,7 +140,32 @@ impl FromMarkerByte for SectionKind {
 /// Encompasses all possible errors that may occur during decoding,
 /// including section-specific errors.
 #[derive(Debug, Error)]
-pub enum DecodeModuleError {
+pub struct DecodeModuleError {
+    pub offset: u64,
+    pub source: DecodeModuleErrorKind,
+}
+
+impl DecodeModuleError {
+    fn new<R, E>(reader: &OffsetReader<R>, source: E) -> Self
+    where
+        R: Read,
+        E: Into<DecodeModuleErrorKind>,
+    {
+        Self {
+            offset: reader.offset,
+            source: source.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for DecodeModuleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} (at offset {:#04X})", self.source, self.offset)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DecodeModuleErrorKind {
     #[error(transparent)]
     ParsePreamble(#[from] ParsePreambleError),
 
@@ -204,8 +250,9 @@ pub enum DecodeModuleError {
 }
 
 /// Decode `input` into a WebAssembly [Module].
-pub fn decode_module(mut input: impl Read) -> Result<Module, DecodeModuleError> {
-    parse_preamble(&mut input)?;
+pub fn decode_module(input: impl Read) -> Result<Module, DecodeModuleError> {
+    let mut input = OffsetReader::new(input);
+    parse_preamble(&mut input).map_err(|e| DecodeModuleError::new(&input, e))?;
 
     let mut module = Module {
         ..Default::default()
@@ -220,96 +267,114 @@ pub fn decode_module(mut input: impl Read) -> Result<Module, DecodeModuleError> 
     // (per section 5.5.16)
     let mut encountered_data_idx_in_code_section = false;
 
-    while let Some(section_header) = decode_section_header(&mut input)? {
-        let mut section_reader = &mut input.by_ref().take(section_header.size.into());
-
-        module.validate_section_kind_expected(&section_header)?;
+    while let Some(section_header) =
+        decode_section_header(&mut input).map_err(|e| DecodeModuleError::new(&input, e))?
+    {
+        module
+            .validate_section_kind_expected(&section_header)
+            .map_err(|e| DecodeModuleError::new(&input, e))?;
 
         let section_kind = section_header.kind;
-        match section_kind {
-            SectionKind::Custom => {
-                module
-                    .custom_sections
-                    .push(decode_section_custom(&mut section_reader)?);
-            }
-            SectionKind::Type => module.types = decode_type_section(section_reader)?,
-            SectionKind::Import => module.imports = decode_import_section(section_reader)?,
-            SectionKind::Function => {
-                for type_idx in decode_function_section(&mut section_reader)? {
-                    module.funcs.push(Func {
-                        r#type: type_idx,
-                        // going to be filled later on by SectionKind::Code
-                        locals: vec![],
-                        body: vec![],
-                    });
-                }
-            }
-            SectionKind::Table => module.tables = decode_table_section(section_reader)?,
-            SectionKind::Memory => module.mems = decode_memory_section(section_reader)?,
-            SectionKind::Global => module.globals = decode_global_section(section_reader)?,
-            SectionKind::Export => module.exports = decode_export_section(section_reader)?,
-            SectionKind::Start => module.start = Some(decode_start_section(section_reader)?),
-            SectionKind::Element => module.elems = decode_element_section(section_reader)?,
-            SectionKind::DataCount => {
-                module.data_count = Some(decode_datacount_section(section_reader)?)
-            }
-            SectionKind::Code => {
-                encountered_code_section = true;
-
-                let codes = decode_code_section(section_reader)?;
-
-                // Section 5.5.17: The lengths of vectors produced by the (possibly empty)
-                // function and code section must match up
-                if codes.len() != module.funcs.len() {
-                    return Err(DecodeModuleError::CodeFuncEntriesLenMismatch {
-                        codes_len: codes.len(),
-                        funcs_len: module.funcs.len(),
-                    });
-                }
-
-                // Section 5.5.17: Furthermore, it [the data count section] must be present if any
-                // data index occurs in the code section.
-                for (i, code) in codes.into_iter().enumerate() {
-                    for local in code.locals {
-                        for _ in 0..local.count {
-                            module.funcs[i].locals.push(local.t);
+        let section_error = {
+            let mut section_reader = &mut input.by_ref().take(section_header.size.into());
+            (|| -> Result<(), DecodeModuleErrorKind> {
+                match section_kind {
+                    SectionKind::Custom => {
+                        module
+                            .custom_sections
+                            .push(decode_section_custom(&mut section_reader)?);
+                    }
+                    SectionKind::Type => module.types = decode_type_section(section_reader)?,
+                    SectionKind::Import => module.imports = decode_import_section(section_reader)?,
+                    SectionKind::Function => {
+                        for type_idx in decode_function_section(&mut section_reader)? {
+                            module.funcs.push(Func {
+                                r#type: type_idx,
+                                // going to be filled later on by SectionKind::Code
+                                locals: vec![],
+                                body: vec![],
+                            });
                         }
                     }
-
-                    if code.encountered_data_index {
-                        encountered_data_idx_in_code_section = true;
+                    SectionKind::Table => module.tables = decode_table_section(section_reader)?,
+                    SectionKind::Memory => module.mems = decode_memory_section(section_reader)?,
+                    SectionKind::Global => module.globals = decode_global_section(section_reader)?,
+                    SectionKind::Export => module.exports = decode_export_section(section_reader)?,
+                    SectionKind::Start => {
+                        module.start = Some(decode_start_section(section_reader)?)
                     }
+                    SectionKind::Element => module.elems = decode_element_section(section_reader)?,
+                    SectionKind::DataCount => {
+                        module.data_count = Some(decode_datacount_section(section_reader)?)
+                    }
+                    SectionKind::Code => {
+                        encountered_code_section = true;
 
-                    module.funcs[i].body = code.expr;
+                        let codes = decode_code_section(section_reader)?;
+
+                        // Section 5.5.17: The lengths of vectors produced by the (possibly empty)
+                        // function and code section must match up
+                        if codes.len() != module.funcs.len() {
+                            return Err(DecodeModuleErrorKind::CodeFuncEntriesLenMismatch {
+                                codes_len: codes.len(),
+                                funcs_len: module.funcs.len(),
+                            });
+                        }
+
+                        // Section 5.5.17: Furthermore, it [the data count section] must be present if any
+                        // data index occurs in the code section.
+                        for (i, code) in codes.into_iter().enumerate() {
+                            for local in code.locals {
+                                for _ in 0..local.count {
+                                    module.funcs[i].locals.push(local.t);
+                                }
+                            }
+
+                            if code.encountered_data_index {
+                                encountered_data_idx_in_code_section = true;
+                            }
+
+                            module.funcs[i].body = code.expr;
+                        }
+                    }
+                    SectionKind::Data => {
+                        let datas = decode_data_section(section_reader)?;
+
+                        // Section 5.5.17: Similarly, the optional data count must match the length of the
+                        // data segment list.
+                        if let Some(data_count) = module.data_count
+                            && datas.len() != usize::try_from(data_count).unwrap()
+                        {
+                            return Err(DecodeModuleErrorKind::DataCountMismatch {
+                                datas_len: datas.len(),
+                                data_count,
+                            });
+                        }
+
+                        module.datas = datas;
+                    }
+                    SectionKind::Tag => module.tags = decode_tag_section(section_reader)?,
                 }
-            }
-            SectionKind::Data => {
-                let datas = decode_data_section(section_reader)?;
 
-                // Section 5.5.17: Similarly, the optional data count must match the length of the
-                // data segment list.
-                if let Some(data_count) = module.data_count
-                    && datas.len() != usize::try_from(data_count).unwrap()
-                {
-                    return Err(DecodeModuleError::DataCountMismatch {
-                        datas_len: datas.len(),
-                        data_count,
+                if section_reader.limit() != 0 {
+                    return Err(DecodeModuleErrorKind::SectionSizeMismatch {
+                        section_kind,
+                        declared: section_header.size,
+                        got: u64::from(section_header.size) - section_reader.limit(),
                     });
                 }
-                module.datas = datas;
-            }
-            SectionKind::Tag => module.tags = decode_tag_section(section_reader)?,
-        }
 
-        if section_reader.limit() != 0 {
-            return Err(DecodeModuleError::SectionSizeMismatch {
-                section_kind,
-                declared: section_header.size,
-                got: u64::from(section_header.size) - section_reader.limit(),
-            });
+                Ok(())
+            })()
+            .err()
+        };
+
+        if let Some(e) = section_error {
+            return Err(DecodeModuleError::new(&input, e));
         }
 
         module.section_headers.push(section_header);
+
         if section_kind != SectionKind::Custom {
             // parsed_section_kinds facilitates enforcing the prescribed order of sections, but
             // Custom sections may appear in any order thus we don't want them in the set
@@ -324,27 +389,32 @@ pub fn decode_module(mut input: impl Read) -> Result<Module, DecodeModuleError> 
         // if we encountered a Code section, it means we already checked that
         // its count matches the Function section count. (Function section comes
         // before Code section.)
-        return Err(DecodeModuleError::CodeFuncEntriesLenMismatch {
+        let e = DecodeModuleErrorKind::CodeFuncEntriesLenMismatch {
             funcs_len: module.funcs.len(),
             codes_len: 0,
-        });
+        };
+        return Err(DecodeModuleError::new(&input, e));
     }
 
     // Section 5.5.17: Similarly, the optional data count must match the length
     // of the data segment vector
     if let Some(n) = module.data_count
-        && usize::try_from(n).map_err(DecodeModuleError::DecodeDataCount)? != module.datas.len()
+        && usize::try_from(n).map_err(|e| {
+            DecodeModuleError::new(&input, DecodeModuleErrorKind::DecodeDataCount(e))
+        })? != module.datas.len()
     {
-        return Err(DecodeModuleError::DataCountDatasLenMismatch {
+        let e = DecodeModuleErrorKind::DataCountDatasLenMismatch {
             datas_len: module.datas.len(),
             data_count: n,
-        });
+        };
+        return Err(DecodeModuleError::new(&input, e));
     }
 
     // Section 5.5.17: Furthermore, it [the data count section] must be present if any data index
     // occurs in the code section
     if encountered_data_idx_in_code_section && module.data_count.is_none() {
-        return Err(DecodeModuleError::DataIndexWithoutDataCount);
+        let e = DecodeModuleErrorKind::DataIndexWithoutDataCount;
+        return Err(DecodeModuleError::new(&input, e));
     }
 
     Ok(module)

--- a/src/decode/types/globaltype.rs
+++ b/src/decode/types/globaltype.rs
@@ -1,7 +1,7 @@
 use crate::core::types::globaltype::{GlobalType, Mut};
 use crate::core::types::valtype::ValType;
-use crate::decode::types::valtype::DecodeValTypeError;
 use crate::decode::FromMarkerByte;
+use crate::decode::types::valtype::DecodeValTypeError;
 use crate::read_byte;
 use phf::phf_ordered_map;
 use std::io::Read;

--- a/src/decode/types/heaptype.rs
+++ b/src/decode/types/heaptype.rs
@@ -1,6 +1,6 @@
 use crate::core::types::heaptype::*;
-use crate::decode::integer::{decode_s33, DecodeS33Error};
 use crate::decode::FromMarkerByte;
+use crate::decode::integer::{DecodeS33Error, decode_s33};
 use crate::read_byte;
 use phf::phf_ordered_map;
 use std::io::Cursor;

--- a/src/decode/types/limits.rs
+++ b/src/decode/types/limits.rs
@@ -1,6 +1,6 @@
 use crate::core::types::addrtype::AddrType;
 use crate::core::types::limits::Limits;
-use crate::decode::integer::{decode_u64, DecodeU64Error};
+use crate::decode::integer::{DecodeU64Error, decode_u64};
 use crate::read_byte;
 use std::io::{self, Read};
 use thiserror::Error;

--- a/src/decode_errors.rs
+++ b/src/decode_errors.rs
@@ -34,6 +34,6 @@ pub use crate::decode::types::{
 };
 pub use crate::decode::{
     DecodeByteVectorError, DecodeFloat32Error, DecodeFloat64Error, DecodeListError,
-    DecodeModuleError, DecodeNameError, DecodeSectionHeaderError, InvalidSectionIdError,
-    ParseExpressionError, ParsePreambleError,
+    DecodeModuleError, DecodeModuleErrorKind, DecodeNameError, DecodeSectionHeaderError,
+    InvalidSectionIdError, ParseExpressionError, ParsePreambleError,
 };

--- a/tests/error_types.rs
+++ b/tests/error_types.rs
@@ -19,8 +19,8 @@ fn type_idx_error_for_overlong_function_index() {
 
     let err = decode_module(wasm).expect_err("overlong type index should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeFunctionSection(DecodeFunctionSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeFunctionSection(DecodeFunctionSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeTypeIdxError(DecodeU32Error::RepresentationTooLong),
@@ -42,8 +42,8 @@ fn decode_u32_error_io_for_section_size() {
 
     let err = decode_module(wasm).expect_err("truncated section size should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeSectionHeader(DecodeSectionHeaderError::DecodeSectionSize(
+    match err.source {
+        DecodeModuleErrorKind::DecodeSectionHeader(DecodeSectionHeaderError::DecodeSectionSize(
             u32_err,
         )) => match u32_err {
             DecodeU32Error::Io(io_err) => {
@@ -65,8 +65,8 @@ fn decode_i32_error_too_large() {
 
     let err = decode_module(wasm).expect_err("too-large i32 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -93,8 +93,8 @@ fn decode_i32_error_representation_too_long() {
 
     let err = decode_module(wasm).expect_err("overlong i32 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -120,8 +120,8 @@ fn decode_i32_error_io() {
 
     let err = decode_module(wasm).expect_err("truncated i32 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -153,8 +153,8 @@ fn decode_i64_error_representation_too_long() {
 
     let err = decode_module(wasm).expect_err("overlong i64 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -181,8 +181,8 @@ fn decode_i64_error_incorrect_sign_extension() {
 
     let err = decode_module(wasm).expect_err("bad i64 sign extension should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -208,8 +208,8 @@ fn decode_i64_error_io() {
 
     let err = decode_module(wasm).expect_err("truncated i64 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -240,8 +240,8 @@ fn parse_error_read_opcode() {
 
     let err = decode_module(wasm).expect_err("missing opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -267,8 +267,8 @@ fn parse_error_control() {
 
     let err = decode_module(wasm).expect_err("invalid label index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -295,8 +295,8 @@ fn parse_error_reference() {
 
     let err = decode_module(wasm).expect_err("invalid heap type should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -324,8 +324,8 @@ fn parse_error_reference_invalid_subopcode() {
 
     let err = decode_module(wasm).expect_err("invalid sub-opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -351,8 +351,8 @@ fn parse_error_control_invalid_cast_nullability_marker() {
 
     let err = decode_module(wasm).expect_err("invalid cast nullability marker should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -378,8 +378,8 @@ fn parse_error_reference_ref_test_negative_heaptype() {
 
     let err = decode_module(wasm).expect_err("invalid heap type should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -407,8 +407,8 @@ fn parse_error_parametric() {
 
     let err = decode_module(wasm).expect_err("invalid valtype in select should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -445,8 +445,8 @@ fn parse_error_variable() {
 
     let err = decode_module(wasm).expect_err("missing global index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -474,8 +474,8 @@ fn parse_error_table() {
 
     let err = decode_module(wasm).expect_err("invalid table index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -502,8 +502,8 @@ fn parse_error_numeric() {
 
     let err = decode_module(wasm).expect_err("truncated f32 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -531,8 +531,8 @@ fn parse_error_vector() {
 
     let err = decode_module(wasm).expect_err("invalid vector opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -558,8 +558,8 @@ fn parse_error_invalid_opcode() {
 
     let err = decode_module(wasm).expect_err("invalid opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -584,8 +584,8 @@ fn parse_error_invalid_marker_after_fc() {
 
     let err = decode_module(wasm).expect_err("invalid FC marker should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -612,8 +612,8 @@ fn control_error_decode_label_idx_vector() {
 
     let err = decode_module(wasm).expect_err("overlong label index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -644,8 +644,8 @@ fn control_error_decode_catch_invalid_marker() {
 
     let err = decode_module(wasm).expect_err("invalid catch marker should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -677,8 +677,8 @@ fn control_error_table_idx() {
 
     let err = decode_module(wasm).expect_err("overlong table index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -705,8 +705,8 @@ fn control_error_type_idx() {
 
     let err = decode_module(wasm).expect_err("overlong type index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -733,8 +733,8 @@ fn control_error_block_type() {
 
     let err = decode_module(wasm).expect_err("missing block type should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -762,8 +762,8 @@ fn control_error_unexpected_else() {
 
     let err = decode_module(wasm).expect_err("double else should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -787,8 +787,8 @@ fn control_error_unexpected_else_in_block() {
 
     let err = decode_module(wasm).expect_err("unexpected else in block should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -812,8 +812,8 @@ fn control_error_unexpected_else_in_loop() {
 
     let err = decode_module(wasm).expect_err("unexpected else in loop should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -837,8 +837,8 @@ fn control_error_unexpected_else_in_try_table() {
 
     let err = decode_module(wasm).expect_err("unexpected else in try_table should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -863,8 +863,8 @@ fn reference_error_func_idx() {
 
     let err = decode_module(wasm).expect_err("overlong ref.func index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -891,8 +891,8 @@ fn func_idx_error_for_overlong_call_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong func idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -919,8 +919,8 @@ fn table_idx_error_for_overlong_table_get_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong table idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -947,8 +947,8 @@ fn mem_idx_error_for_overlong_data_segment_memory_index() {
 
     let err = decode_module(wasm).expect_err("overlong mem idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeDataSection(DecodeDataSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeDataSection(DecodeDataSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -972,8 +972,8 @@ fn global_idx_error_for_overlong_global_get_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong global idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -999,8 +999,8 @@ fn elem_idx_error_for_overlong_elem_drop_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong elem idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1026,8 +1026,8 @@ fn data_idx_error_for_overlong_data_drop_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong data idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1053,8 +1053,8 @@ fn local_idx_error_for_overlong_local_get_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong local idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1080,8 +1080,8 @@ fn label_idx_error_for_overlong_br_instruction() {
 
     let err = decode_module(wasm).expect_err("overlong label idx should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1107,8 +1107,8 @@ fn decode_u32_error_too_large_for_type_section_length() {
 
     let err = decode_module(wasm).expect_err("too-large vector length should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
             DecodeListError::DecodeLength(u32_err),
         )) => {
             assert!(
@@ -1130,8 +1130,8 @@ fn decode_u32_error_representation_too_long_for_section_size() {
 
     let err = decode_module(wasm).expect_err("overlong section size should fail to decode");
 
-    match err {
-        DecodeModuleError::DecodeSectionHeader(DecodeSectionHeaderError::DecodeSectionSize(
+    match err.source {
+        DecodeModuleErrorKind::DecodeSectionHeader(DecodeSectionHeaderError::DecodeSectionSize(
             u32_err,
         )) => assert!(
             matches!(u32_err, DecodeU32Error::RepresentationTooLong),
@@ -1152,8 +1152,8 @@ fn parametric_error_decode_vector_invalid_valtype() {
 
     let err = decode_module(wasm).expect_err("invalid type vector in select should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1191,8 +1191,8 @@ fn memory_error_decode_memarg_missing_offset() {
 
     let err = decode_module(wasm).expect_err("missing memarg offset should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1222,8 +1222,8 @@ fn numeric_error_read_opcode_truncated_fc_prefix() {
 
     let err = decode_module(wasm).expect_err("truncated 0xFC opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1253,8 +1253,8 @@ fn numeric_error_decode_f32_truncated_payload() {
 
     let err = decode_module(wasm).expect_err("truncated f32 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1283,8 +1283,8 @@ fn numeric_error_decode_f64_truncated_payload() {
 
     let err = decode_module(wasm).expect_err("truncated f64 const should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1313,8 +1313,8 @@ fn vector_error_read_opcode_truncated() {
 
     let err = decode_module(wasm).expect_err("truncated vector opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1344,8 +1344,8 @@ fn vector_error_memarg_offset_missing() {
 
     let err = decode_module(wasm).expect_err("missing memarg offset should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1372,8 +1372,8 @@ fn vector_error_laneidx_missing() {
 
     let err = decode_module(wasm).expect_err("missing lane idx should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1398,8 +1398,8 @@ fn vector_error_read_immediate_bytes() {
 
     let err = decode_module(wasm).expect_err("truncated vector immediate should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1424,8 +1424,8 @@ fn vector_error_invalid_opcode() {
 
     let err = decode_module(wasm).expect_err("invalid vector opcode should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1450,8 +1450,8 @@ fn memarg_error_align_missing() {
 
     let err = decode_module(wasm).expect_err("missing memarg align should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1479,8 +1479,8 @@ fn memarg_error_invalid_flags_bit() {
 
     let err = decode_module(wasm).expect_err("invalid memarg flags should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1507,8 +1507,8 @@ fn lane_idx_error_missing_byte() {
 
     let err = decode_module(wasm).expect_err("missing lane idx should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1533,8 +1533,8 @@ fn block_type_error_read_marker_byte() {
 
     let err = decode_module(wasm).expect_err("missing block type should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1561,8 +1561,8 @@ fn block_type_error_decode_index_truncated() {
 
     let err = decode_module(wasm).expect_err("truncated block type index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1589,8 +1589,8 @@ fn block_type_error_negative_type_index() {
 
     let err = decode_module(wasm).expect_err("negative block type index should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1618,8 +1618,8 @@ fn decode_rec_type_error_read_marker_byte() {
 
     let err = decode_module(wasm).expect_err("missing rectype marker should fail");
 
-    match err {
-        DecodeModuleError::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeRecTypeError::Io(io_err),
@@ -1643,8 +1643,8 @@ fn decode_rec_type_error_invalid_marker_byte() {
 
     let err = decode_module(wasm).expect_err("invalid composite type marker should fail");
 
-    match err {
-        DecodeModuleError::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1671,8 +1671,8 @@ fn decode_rec_type_error_parameter_types_invalid_valtype() {
 
     let err = decode_module(wasm).expect_err("invalid parameter valtype should fail");
 
-    match err {
-        DecodeModuleError::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1710,8 +1710,8 @@ fn decode_rec_type_error_result_types_truncated() {
 
     let err = decode_module(wasm).expect_err("truncated result valtype should fail");
 
-    match err {
-        DecodeModuleError::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTypeSection(DecodeTypeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1742,8 +1742,8 @@ fn decode_table_error_invalid_reftype_marker() {
 
     let err = decode_module(wasm).expect_err("invalid table reftype should fail");
 
-    match err {
-        DecodeModuleError::DecodeTableSection(DecodeTableSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTableSection(DecodeTableSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1770,8 +1770,8 @@ fn decode_table_error_reftype_truncated() {
 
     let err = decode_module(wasm).expect_err("truncated table reftype should fail");
 
-    match err {
-        DecodeModuleError::DecodeTableSection(DecodeTableSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTableSection(DecodeTableSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeTableError::Io(io_err),
@@ -1794,8 +1794,8 @@ fn decode_table_error_limits_invalid_flag() {
 
     let err = decode_module(wasm).expect_err("invalid table limits flag should fail");
 
-    match err {
-        DecodeModuleError::DecodeTableSection(DecodeTableSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTableSection(DecodeTableSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1817,8 +1817,8 @@ fn decode_memory_type_error_missing_limits_byte() {
 
     let err = decode_module(wasm).expect_err("missing limits should fail");
 
-    match err {
-        DecodeModuleError::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeMemoryTypeError(ParseLimitsError::ReadFlagByte(io_err)),
@@ -1841,8 +1841,8 @@ fn decode_memory_type_error_unexpected_max_limit_byte() {
 
     let err = decode_module(wasm).expect_err("unexpected limits flag should fail");
 
-    match err {
-        DecodeModuleError::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeMemoryTypeError(ParseLimitsError::UnexpectedFlagByte(0x02)),
@@ -1863,8 +1863,8 @@ fn decode_memory_type_error_missing_min_limit() {
 
     let err = decode_module(wasm).expect_err("missing min limit should fail");
 
-    match err {
-        DecodeModuleError::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1887,8 +1887,8 @@ fn decode_memory_type_error_missing_max_limit() {
 
     let err = decode_module(wasm).expect_err("missing max limit should fail");
 
-    match err {
-        DecodeModuleError::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeMemorySection(DecodeMemorySectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1911,8 +1911,8 @@ fn decode_global_type_error_invalid_valtype() {
 
     let err = decode_module(wasm).expect_err("invalid global valtype should fail");
 
-    match err {
-        DecodeModuleError::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1940,8 +1940,8 @@ fn decode_global_type_error_missing_mutability() {
 
     let err = decode_module(wasm).expect_err("missing mutability should fail");
 
-    match err {
-        DecodeModuleError::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1965,8 +1965,8 @@ fn decode_global_type_error_invalid_mutability() {
 
     let err = decode_module(wasm).expect_err("invalid mutability should fail");
 
-    match err {
-        DecodeModuleError::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -1989,8 +1989,8 @@ fn parse_preamble_error_io() {
 
     let err = decode_module(wasm).expect_err("truncated preamble should fail");
 
-    match err {
-        DecodeModuleError::ParsePreamble(ParsePreambleError::Io(io_err)) => {
+    match err.source {
+        DecodeModuleErrorKind::ParsePreamble(ParsePreambleError::Io(io_err)) => {
             assert_eq!(io_err.kind(), std::io::ErrorKind::UnexpectedEof);
         }
         other => panic!("unexpected error: {other:?}"),
@@ -2006,8 +2006,8 @@ fn parse_preamble_error_unexpected() {
 
     let err = decode_module(wasm).expect_err("wrong preamble should fail");
 
-    match err {
-        DecodeModuleError::ParsePreamble(ParsePreambleError::Unexpected(bytes)) => {
+    match err.source {
+        DecodeModuleErrorKind::ParsePreamble(ParsePreambleError::Unexpected(bytes)) => {
             assert_ne!(bytes, *b"\0asm\x01\0\0\0");
         }
         other => panic!("unexpected error: {other:?}"),
@@ -2023,8 +2023,8 @@ fn decode_section_header_error_invalid_section_id() {
 
     let err = decode_module(wasm).expect_err("invalid section id should fail");
 
-    match err {
-        DecodeModuleError::DecodeSectionHeader(DecodeSectionHeaderError::InvalidSectionId(err)) => {
+    match err.source {
+        DecodeModuleErrorKind::DecodeSectionHeader(DecodeSectionHeaderError::InvalidSectionId(err)) => {
             assert_eq!(err.0, 0x0E);
         }
         other => panic!("unexpected error: {other:?}"),
@@ -2040,8 +2040,8 @@ fn decode_module_section_out_of_order() {
 
     let err = decode_module(wasm).expect_err("out-of-order sections should fail");
 
-    match err {
-        DecodeModuleError::SectionOutOfOrder { current, previous } => {
+    match err.source {
+        DecodeModuleErrorKind::SectionOutOfOrder { current, previous } => {
             assert_eq!(current, SectionKind::Type);
             assert_eq!(previous, SectionKind::Memory);
         }
@@ -2058,8 +2058,8 @@ fn decode_module_duplicate_section() {
 
     let err = decode_module(wasm).expect_err("duplicate type section should fail");
 
-    match err {
-        DecodeModuleError::DuplicateSection(kind) => assert_eq!(kind, SectionKind::Type),
+    match err.source {
+        DecodeModuleErrorKind::DuplicateSection(kind) => assert_eq!(kind, SectionKind::Type),
         other => panic!("unexpected error: {other:?}"),
     }
 }
@@ -2073,8 +2073,8 @@ fn decode_module_section_size_mismatch() {
 
     let err = decode_module(wasm).expect_err("section size mismatch should fail");
 
-    match err {
-        DecodeModuleError::SectionSizeMismatch {
+    match err.source {
+        DecodeModuleErrorKind::SectionSizeMismatch {
             section_kind,
             declared,
             got,
@@ -2095,8 +2095,8 @@ fn decode_module_code_func_entries_len_mismatch() {
 
     let err = decode_module(wasm).expect_err("function/code length mismatch should fail");
 
-    match err {
-        DecodeModuleError::CodeFuncEntriesLenMismatch {
+    match err.source {
+        DecodeModuleErrorKind::CodeFuncEntriesLenMismatch {
             codes_len,
             funcs_len,
         } => {
@@ -2116,8 +2116,8 @@ fn decode_module_data_count_mismatch() {
 
     let err = decode_module(wasm).expect_err("data count mismatch should fail");
 
-    match err {
-        DecodeModuleError::DataCountMismatch {
+    match err.source {
+        DecodeModuleErrorKind::DataCountMismatch {
             datas_len,
             data_count,
         } => {
@@ -2137,8 +2137,8 @@ fn decode_module_data_count_datas_len_mismatch() {
 
     let err = decode_module(wasm).expect_err("data count datas len mismatch should fail");
 
-    match err {
-        DecodeModuleError::DataCountDatasLenMismatch {
+    match err.source {
+        DecodeModuleErrorKind::DataCountDatasLenMismatch {
             datas_len,
             data_count,
         } => {
@@ -2158,8 +2158,8 @@ fn decode_module_data_index_without_data_count() {
 
     let err = decode_module(wasm).expect_err("data index without data count should fail");
 
-    match err {
-        DecodeModuleError::DataIndexWithoutDataCount => {}
+    match err.source {
+        DecodeModuleErrorKind::DataIndexWithoutDataCount => {}
         other => panic!("unexpected error: {other:?}"),
     }
 }
@@ -2178,8 +2178,8 @@ fn decode_module_data_index_without_data_count_nested_controls() {
 
     let err = decode_module(wasm).expect_err("nested data indices without data count should fail");
 
-    match err {
-        DecodeModuleError::DataIndexWithoutDataCount => {}
+    match err.source {
+        DecodeModuleErrorKind::DataIndexWithoutDataCount => {}
         other => panic!("unexpected error: {other:?}"),
     }
 }
@@ -2193,8 +2193,8 @@ fn decode_custom_section_error_decode_name_length() {
 
     let err = decode_module(wasm).expect_err("overlong custom name length should fail");
 
-    match err {
-        DecodeModuleError::DecodeCustomSection(DecodeCustomSectionError::DecodeName(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCustomSection(DecodeCustomSectionError::DecodeName(
             DecodeNameError::DecodeByteVector(DecodeByteVectorError::DecodeLength(
                 DecodeU32Error::RepresentationTooLong,
             )),
@@ -2212,8 +2212,8 @@ fn decode_custom_section_error_decode_name_truncated() {
 
     let err = decode_module(wasm).expect_err("truncated custom name should fail");
 
-    match err {
-        DecodeModuleError::DecodeCustomSection(DecodeCustomSectionError::DecodeName(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCustomSection(DecodeCustomSectionError::DecodeName(
             DecodeNameError::DecodeByteVector(DecodeByteVectorError::ReadElements(io_err)),
         )) => assert_eq!(io_err.kind(), std::io::ErrorKind::UnexpectedEof),
         other => panic!("unexpected error: {other:?}"),
@@ -2229,8 +2229,8 @@ fn decode_custom_section_error_invalid_utf8_name() {
 
     let err = decode_module(wasm).expect_err("invalid utf8 in custom name should fail");
 
-    match err {
-        DecodeModuleError::DecodeCustomSection(DecodeCustomSectionError::DecodeName(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCustomSection(DecodeCustomSectionError::DecodeName(
             DecodeNameError::Utf8(err),
         )) => {
             let utf8_err = err.utf8_error();
@@ -2250,8 +2250,8 @@ fn decode_import_section_error_module_name() {
 
     let err = decode_module(wasm).expect_err("invalid import module name should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2276,8 +2276,8 @@ fn decode_import_section_error_entity_name_utf8() {
 
     let err = decode_module(wasm).expect_err("invalid import entity name should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeImportError::DecodeItemName(DecodeNameError::Utf8(err)),
@@ -2301,8 +2301,8 @@ fn decode_import_error_descriptor_missing_byte() {
 
     let err = decode_module(wasm).expect_err("missing import descriptor should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2325,8 +2325,8 @@ fn decode_import_error_invalid_descriptor() {
 
     let err = decode_module(wasm).expect_err("invalid import descriptor should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2349,8 +2349,8 @@ fn decode_import_error_typeidx_overlong() {
 
     let err = decode_module(wasm).expect_err("overlong import type idx should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2374,8 +2374,8 @@ fn decode_import_error_table_invalid_reftype() {
 
     let err = decode_module(wasm).expect_err("invalid import table reftype should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2402,8 +2402,8 @@ fn decode_import_error_memory_invalid_limits() {
 
     let err = decode_module(wasm).expect_err("invalid import memory limits should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2428,8 +2428,8 @@ fn decode_import_error_global_invalid_mutability() {
 
     let err = decode_module(wasm).expect_err("invalid import global mutability should fail");
 
-    match err {
-        DecodeModuleError::DecodeImportSection(DecodeImportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeImportSection(DecodeImportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2454,8 +2454,8 @@ fn decode_export_section_error_name_decode() {
 
     let err = decode_module(wasm).expect_err("invalid export name should fail");
 
-    match err {
-        DecodeModuleError::DecodeExportSection(DecodeExportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeExportSection(DecodeExportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2479,8 +2479,8 @@ fn decode_export_error_descriptor_missing_byte() {
 
     let err = decode_module(wasm).expect_err("missing export descriptor should fail");
 
-    match err {
-        DecodeModuleError::DecodeExportSection(DecodeExportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeExportSection(DecodeExportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeExportError::ReadDescriptorMarkerByte(io_err),
@@ -2502,8 +2502,8 @@ fn decode_export_error_index_decode() {
 
     let err = decode_module(wasm).expect_err("overlong export index should fail");
 
-    match err {
-        DecodeModuleError::DecodeExportSection(DecodeExportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeExportSection(DecodeExportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeExportError::DecodeIndex(u32_err),
@@ -2528,8 +2528,8 @@ fn decode_export_error_invalid_descriptor() {
 
     let err = decode_module(wasm).expect_err("invalid export descriptor should fail");
 
-    match err {
-        DecodeModuleError::DecodeExportSection(DecodeExportSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeExportSection(DecodeExportSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeExportError::InvalidDescriptorMarkerByte(err),
@@ -2551,8 +2551,8 @@ fn decode_start_section_error_func_idx() {
 
     let err = decode_module(wasm).expect_err("overlong start func idx should fail");
 
-    match err {
-        DecodeModuleError::DecodeStartSection(DecodeStartSectionError(DecodeFuncIdxError(
+    match err.source {
+        DecodeModuleErrorKind::DecodeStartSection(DecodeStartSectionError(DecodeFuncIdxError(
             DecodeU32Error::TooLarge,
         ))) => {}
         other => panic!("unexpected error: {other:?}"),
@@ -2569,8 +2569,8 @@ fn decode_code_error_function_size_truncated() {
 
     let err = decode_module(wasm).expect_err("missing code size should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeCodeError::DecodeFunctionSize(u32_err),
@@ -2599,8 +2599,8 @@ fn decode_code_error_locals_vector_length_overlong() {
 
     let err = decode_module(wasm).expect_err("overlong locals vector length should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2623,8 +2623,8 @@ fn decode_code_locals_error_count_out_of_bounds() {
 
     let err = decode_module(wasm).expect_err("too many locals should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2657,8 +2657,8 @@ fn decode_code_locals_error_decode_count() {
 
     let err = decode_module(wasm).expect_err("truncated locals count should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2686,8 +2686,8 @@ fn decode_code_error_local_valtype_invalid() {
 
     let err = decode_module(wasm).expect_err("invalid local valtype should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2722,8 +2722,8 @@ fn decode_code_error_entry_size_mismatch() {
 
     let err = decode_module(wasm).expect_err("entry size mismatch should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2752,8 +2752,8 @@ fn parse_expression_error_unexpected_else() {
 
     let err = decode_module(wasm).expect_err("unexpected else should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeCodeError::DecodeFunctionBody(ParseExpressionError::UnexpectedElse),
@@ -2774,8 +2774,8 @@ fn decode_element_section_error_bitfield_decode() {
 
     let err = decode_module(wasm).expect_err("element bitfield decode should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeElementError::DecodeBitfield(DecodeU32Error::RepresentationTooLong),
@@ -2794,8 +2794,8 @@ fn decode_element_error_invalid_bitfield() {
 
     let err = decode_module(wasm).expect_err("invalid element bitfield should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeElementError::InvalidBitfield(n),
@@ -2817,8 +2817,8 @@ fn decode_element_error_offset_expression() {
 
     let err = decode_module(wasm).expect_err("missing offset expr should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2843,8 +2843,8 @@ fn decode_element_error_elemkind_invalid() {
 
     let err = decode_module(wasm).expect_err("invalid element kind should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2866,8 +2866,8 @@ fn decode_element_error_elemkind_io() {
 
     let err = decode_module(wasm).expect_err("missing elemkind byte should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeElementError::DecodeElementKind(DecodeElementKindError::Io(io_err)),
@@ -2889,8 +2889,8 @@ fn decode_element_error_reference_type_invalid() {
 
     let err = decode_module(wasm).expect_err("invalid element ref type should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2915,8 +2915,8 @@ fn decode_element_error_init_decode_length() {
 
     let err = decode_module(wasm).expect_err("invalid element init vector should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2940,8 +2940,8 @@ fn decode_element_error_funcidx_vector_overlong() {
 
     let err = decode_module(wasm).expect_err("overlong funcidx vector should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2967,8 +2967,8 @@ fn decode_element_error_table_idx_overlong() {
 
     let err = decode_module(wasm).expect_err("overlong table idx should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -2991,8 +2991,8 @@ fn decode_element_error_expression_missing_opcode() {
 
     let err = decode_module(wasm).expect_err("missing element expression should fail");
 
-    match err {
-        DecodeModuleError::DecodeElementSection(DecodeElementSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeElementSection(DecodeElementSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -3017,8 +3017,8 @@ fn decode_data_section_error_bitfield_decode() {
 
     let err = decode_module(wasm).expect_err("data bitfield decode should fail");
 
-    match err {
-        DecodeModuleError::DecodeDataSection(DecodeDataSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeDataSection(DecodeDataSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -3040,8 +3040,8 @@ fn decode_data_section_error_invalid_bitfield() {
 
     let err = decode_module(wasm).expect_err("invalid data bitfield should fail");
 
-    match err {
-        DecodeModuleError::DecodeDataSection(DecodeDataSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeDataSection(DecodeDataSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeDataSegmentError::InvalidBitfield(n),
@@ -3063,8 +3063,8 @@ fn decode_data_section_error_offset_expr_missing() {
 
     let err = decode_module(wasm).expect_err("missing data offset expr should fail");
 
-    match err {
-        DecodeModuleError::DecodeDataSection(DecodeDataSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeDataSection(DecodeDataSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -3089,8 +3089,8 @@ fn decode_data_section_error_init_vector_truncated() {
 
     let err = decode_module(wasm).expect_err("truncated data init vector should fail");
 
-    match err {
-        DecodeModuleError::DecodeDataSection(DecodeDataSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeDataSection(DecodeDataSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -3115,8 +3115,8 @@ fn decode_datacount_section_error_decode_segment_count() {
 
     let err = decode_module(wasm).expect_err("data count decode should fail");
 
-    match err {
-        DecodeModuleError::DecodeDatacountSection(
+    match err.source {
+        DecodeModuleErrorKind::DecodeDatacountSection(
             DecodeDataCountSectionError::DecodeDataSegmentCount(
                 DecodeU32Error::RepresentationTooLong,
             ),
@@ -3135,8 +3135,8 @@ fn decode_global_error_init_missing_expr() {
 
     let err = decode_module(wasm).expect_err("missing global init should fail");
 
-    match err {
-        DecodeModuleError::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeGlobalSection(DecodeGlobalSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -3161,8 +3161,8 @@ fn decode_tag_section_error_invalid_marker() {
 
     let err = decode_module(wasm).expect_err("invalid tagtype marker should fail");
 
-    match err {
-        DecodeModuleError::DecodeTagSection(DecodeTagSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeTagSection(DecodeTagSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeTagTypeError::InvalidMarkerByte(byte),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -62,8 +62,8 @@ fn rectypes(comptypes: Vec<CompType>) -> Vec<RecType> {
 fn it_parses_preamble() {
     let mut input: &[u8] = &[];
     let err = decode_module(input).expect_err("empty input should fail");
-    match err {
-        DecodeModuleError::ParsePreamble(ParsePreambleError::Io(io_err)) => {
+    match err.source {
+        DecodeModuleErrorKind::ParsePreamble(ParsePreambleError::Io(io_err)) => {
             assert_eq!(io_err.kind(), std::io::ErrorKind::UnexpectedEof);
         }
         other => panic!("unexpected error: {other:?}"),
@@ -71,8 +71,8 @@ fn it_parses_preamble() {
 
     input = &[0xD3, 0xAD, 0xBE, 0xEF];
     let err = decode_module(input).expect_err("short preamble should fail");
-    match err {
-        DecodeModuleError::ParsePreamble(ParsePreambleError::Io(io_err)) => {
+    match err.source {
+        DecodeModuleErrorKind::ParsePreamble(ParsePreambleError::Io(io_err)) => {
             assert_eq!(io_err.kind(), std::io::ErrorKind::UnexpectedEof);
         }
         other => panic!("unexpected error: {other:?}"),
@@ -80,8 +80,8 @@ fn it_parses_preamble() {
 
     input = &[0xD3, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00];
     let err = decode_module(input).expect_err("wrong preamble should fail");
-    match err {
-        DecodeModuleError::ParsePreamble(ParsePreambleError::Unexpected(preamble)) => {
+    match err.source {
+        DecodeModuleErrorKind::ParsePreamble(ParsePreambleError::Unexpected(preamble)) => {
             assert_eq!(preamble, [0xD3, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00]);
         }
         other => panic!("unexpected error: {other:?}"),
@@ -3405,8 +3405,8 @@ fn it_decodes_memory64_limits_large_values() {
 fn it_fails_on_code_size_mismatch() {
     let f = File::open("tests/fixtures/code_section_size_underreported.wasm").unwrap();
     let err = decode_module(f).expect_err("underreported code section should fail");
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:
@@ -3423,8 +3423,8 @@ fn it_fails_on_code_size_mismatch() {
 
     let f = File::open("tests/fixtures/custom_section_size_overreported.wasm").unwrap();
     let err = decode_module(f).expect_err("overreported custom section should fail");
-    match err {
-        DecodeModuleError::SectionSizeMismatch {
+    match err.source {
+        DecodeModuleErrorKind::SectionSizeMismatch {
             section_kind,
             declared,
             got,
@@ -3457,8 +3457,8 @@ fn it_rejects_overlong_type_index_encoding() {
 
     let err = decode_module(module).expect_err("module should fail while reading type index");
 
-    match err {
-        DecodeModuleError::DecodeFunctionSection(DecodeFunctionSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeFunctionSection(DecodeFunctionSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source: DecodeTypeIdxError(DecodeU32Error::RepresentationTooLong),
@@ -3476,8 +3476,8 @@ fn it_rejects_overlong_blocktype_s33() {
     let err = decode_module(File::open(path).unwrap())
         .expect_err("overlong s33 blocktype encoding should fail");
 
-    match err {
-        DecodeModuleError::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
+    match err.source {
+        DecodeModuleErrorKind::DecodeCodeSection(DecodeCodeSectionError::DecodeList(
             DecodeListError::ParseElement {
                 position,
                 source:


### PR DESCRIPTION
We introduce `OffsetReader`, which is a thin wrapper around an `std::io::Read` and stores the amount of bytes consumed so far. We then use that information to make `DecodeModuleError` more useful, by including the offset at which a decoding error occurred.

Also, executed `cargo fmt` in the process.

Resolves #22